### PR TITLE
Creating a self CA for SSL connections when testing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,17 @@
     - testing is defined
     - letsencrypt_cert.stat.exists == False
 
+- name: Create live directory for testing CA
+  file:
+    dest: /etc/letsencrypt/live/CA
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when:
+    - testing is defined
+    - letsencrypt_cert.stat.exists == False
+
 - name: Install openssl
   apt:
     pkg: openssl
@@ -72,11 +83,45 @@
     - testing is defined
     - letsencrypt_cert.stat.exists == False
 
+- name: Create self-signed root certificate (CA), if testing.
+  command: >
+    openssl req -x509 -new -nodes -subj '/CN=lili' -days 30
+    -newkey rsa:4096 -sha256 -keyout /etc/letsencrypt/live/CA/rootCA.key
+    -out /etc/letsencrypt/live/CA/rootCA.pem
+  args:
+    creates: /etc/letsencrypt/live/CA/rootCA.pem
+  ignore_errors: yes
+  when:
+    - testing is defined
+    - letsencrypt_cert.stat.exists == False
+
 - name: Create self-signed certificate, if testing.
   command: >
-    openssl req -x509 -nodes -subj '/CN={{ domain }}' -days 30
-    -newkey rsa:4096 -sha256 -keyout /etc/letsencrypt/live/{{ domain }}/privkey.pem
-    -out /etc/letsencrypt/live/{{ domain }}/cert.pem
+    openssl req -new -nodes -subj '/CN=lili' -days 30 \
+    -newkey rsa:4096 -sha256 -keyout /etc/letsencrypt/live/{{ domain }}/privkey.pem \
+    -out /etc/letsencrypt/live/{{ domain }}/cert.csr
+  args:
+    creates: /etc/letsencrypt/live/{{ domain }}/cert.csr
+  ignore_errors: yes
+  when:
+    - testing is defined
+    - letsencrypt_cert.stat.exists == False
+
+- name: Create X.509 v3 configuration file
+  template:
+    src: san_template.ext.j2
+    dest: "/etc/letsencrypt/live/{{ domain }}/{{ domain }}.ext"
+  ignore_errors: yes
+  when:
+    - testing is defined
+
+- name: Create self-signed certificate, if testing.
+  command: >
+    openssl x509 -req -in /etc/letsencrypt/live/{{ domain }}/cert.csr
+    -CA /etc/letsencrypt/live/CA/rootCA.pem
+    -CAkey /etc/letsencrypt/live/CA/rootCA.key
+    -CAcreateserial -out /etc/letsencrypt/live/{{ domain }}/cert.pem
+    -days 30 -sha256 -extfile /etc/letsencrypt/live/{{ domain }}/{{ domain }}.ext
   args:
     creates: /etc/letsencrypt/live/{{ domain }}/cert.pem
   ignore_errors: yes

--- a/templates/san_template.ext.j2
+++ b/templates/san_template.ext.j2
@@ -1,0 +1,7 @@
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = {{ domain }}


### PR DESCRIPTION
Creating a self CA for signing certificates when testing. Otherwise, chrome dont accept connections to localhost, because certificate is not valid.

Using this [doc](https://medium.com/@tbusser/creating-a-browser-trusted-self-signed-ssl-certificate-2709ce43fd15) and [this one](https://deliciousbrains.com/ssl-certificate-authority-for-local-https-development/)

To establish SSL connection, add the rootCA.pem to your system certificates, located on the host machine on `/etc/letsencrypt/live/CA/rootCA.pem`.